### PR TITLE
Update dependencies, including adding the missing click dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN rm -f /etc/apt/apt.conf.d/docker-clean; \
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update -y && apt-get upgrade -y && apt-get install -y git
+    apt-get update -y && apt-get upgrade -y && apt-get install -y git g++
 
 WORKDIR /billing-collector
 

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ requirements-update: venv
 	./venv/bin/pip-compile --extra dev -o requirements-dev.txt -U
 
 venv:
-	virtualenv -p python3.11 venv
+	virtualenv -p python3.12 venv
 	./venv/bin/python -m ensurepip -U
 	./venv/bin/pip3 install pip-tools
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,8 @@ dependencies = [
   "requests>=2.32,<3",
   "opentelemetry-api>=1.31,<2",
   "opentelemetry-sdk>=1.31,<2",
-  "eodhp-utils @ git+https://github.com/UKEODHP/eodhp-utils@v0.1.8"
+  "click<9",
+  "eodhp-utils @ git+https://github.com/UKEODHP/eodhp-utils@v0.1.11"
 ]
 
 # List additional groups of dependencies here (e.g. development

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,25 +10,26 @@ attrs==25.3.0
     #   referencing
 black==25.1.0
     # via billing-collector (pyproject.toml)
-boto3==1.37.35
+boto3==1.38.16
     # via eodhp-utils
-botocore==1.37.35
+botocore==1.38.16
     # via
     #   boto3
     #   eodhp-utils
     #   s3transfer
 build==1.2.2.post1
     # via pip-tools
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   pulsar-client
     #   requests
 cfgv==3.4.0
     # via pre-commit
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
-click==8.1.8
+click==8.2.0
     # via
+    #   billing-collector (pyproject.toml)
     #   black
     #   pip-tools
 deprecated==1.2.18
@@ -37,15 +38,15 @@ deprecated==1.2.18
     #   opentelemetry-semantic-conventions
 distlib==0.3.9
     # via virtualenv
-eodhp-utils @ git+https://github.com/UKEODHP/eodhp-utils@v0.1.8
+eodhp-utils @ git+https://github.com/UKEODHP/eodhp-utils@v0.1.11
     # via billing-collector (pyproject.toml)
 execnet==2.1.1
     # via pytest-xdist
-faker==37.1.0
+faker==37.3.0
     # via eodhp-utils
 filelock==3.18.0
     # via virtualenv
-identify==2.6.9
+identify==2.6.10
     # via pre-commit
 idna==3.10
     # via requests
@@ -61,13 +62,13 @@ jmespath==1.0.1
     #   botocore
 jsonschema==4.23.0
     # via eodhp-utils
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2025.4.1
     # via jsonschema
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via black
 nodeenv==1.9.1
     # via pre-commit
-opentelemetry-api==1.32.1
+opentelemetry-api==1.33.0
     # via
     #   billing-collector (pyproject.toml)
     #   eodhp-utils
@@ -76,22 +77,22 @@ opentelemetry-api==1.32.1
     #   opentelemetry-processor-baggage
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-instrumentation==0.53b1
+opentelemetry-instrumentation==0.54b0
     # via opentelemetry-instrumentation-logging
-opentelemetry-instrumentation-logging==0.53b1
+opentelemetry-instrumentation-logging==0.54b0
     # via eodhp-utils
-opentelemetry-processor-baggage==0.53b1
+opentelemetry-processor-baggage==0.54b0
     # via eodhp-utils
-opentelemetry-sdk==1.32.1
+opentelemetry-sdk==1.33.0
     # via
     #   billing-collector (pyproject.toml)
     #   eodhp-utils
     #   opentelemetry-processor-baggage
-opentelemetry-semantic-conventions==0.53b1
+opentelemetry-semantic-conventions==0.54b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-sdk
-packaging==24.2
+packaging==25.0
     # via
     #   black
     #   build
@@ -101,15 +102,15 @@ pathspec==0.12.1
     # via black
 pip-tools==7.4.1
     # via billing-collector (pyproject.toml)
-platformdirs==4.3.7
+platformdirs==4.3.8
     # via
     #   black
     #   virtualenv
-pluggy==1.5.0
+pluggy==1.6.0
     # via pytest
 pre-commit==4.2.0
     # via billing-collector (pyproject.toml)
-pulsar-client==3.6.1
+pulsar-client==3.7.0
     # via
     #   billing-collector (pyproject.toml)
     #   eodhp-utils
@@ -117,6 +118,8 @@ pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
+pysubnettree==0.37
+    # via eodhp-utils
 pytest==8.3.5
     # via
     #   billing-collector (pyproject.toml)
@@ -139,14 +142,16 @@ referencing==0.36.2
     #   jsonschema
     #   jsonschema-specifications
 requests==2.32.3
-    # via billing-collector (pyproject.toml)
-rpds-py==0.24.0
+    # via
+    #   billing-collector (pyproject.toml)
+    #   eodhp-utils
+rpds-py==0.25.0
     # via
     #   jsonschema
     #   referencing
-ruff==0.11.5
+ruff==0.11.10
     # via billing-collector (pyproject.toml)
-s3transfer==0.11.4
+s3transfer==0.12.0
     # via boto3
 six==1.17.0
     # via python-dateutil
@@ -160,7 +165,7 @@ urllib3==2.4.0
     # via
     #   botocore
     #   requests
-virtualenv==20.30.0
+virtualenv==20.31.2
     # via pre-commit
 watchdog==6.0.0
     # via pytest-watcher

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,26 +8,28 @@ attrs==25.3.0
     # via
     #   jsonschema
     #   referencing
-boto3==1.37.35
+boto3==1.38.16
     # via eodhp-utils
-botocore==1.37.35
+botocore==1.38.16
     # via
     #   boto3
     #   eodhp-utils
     #   s3transfer
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   pulsar-client
     #   requests
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
+click==8.2.0
+    # via billing-collector (pyproject.toml)
 deprecated==1.2.18
     # via
     #   opentelemetry-api
     #   opentelemetry-semantic-conventions
-eodhp-utils @ git+https://github.com/UKEODHP/eodhp-utils@v0.1.8
+eodhp-utils @ git+https://github.com/UKEODHP/eodhp-utils@v0.1.11
     # via billing-collector (pyproject.toml)
-faker==37.1.0
+faker==37.3.0
     # via eodhp-utils
 idna==3.10
     # via requests
@@ -39,9 +41,9 @@ jmespath==1.0.1
     #   botocore
 jsonschema==4.23.0
     # via eodhp-utils
-jsonschema-specifications==2024.10.1
+jsonschema-specifications==2025.4.1
     # via jsonschema
-opentelemetry-api==1.32.1
+opentelemetry-api==1.33.0
     # via
     #   billing-collector (pyproject.toml)
     #   eodhp-utils
@@ -50,27 +52,29 @@ opentelemetry-api==1.32.1
     #   opentelemetry-processor-baggage
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-instrumentation==0.53b1
+opentelemetry-instrumentation==0.54b0
     # via opentelemetry-instrumentation-logging
-opentelemetry-instrumentation-logging==0.53b1
+opentelemetry-instrumentation-logging==0.54b0
     # via eodhp-utils
-opentelemetry-processor-baggage==0.53b1
+opentelemetry-processor-baggage==0.54b0
     # via eodhp-utils
-opentelemetry-sdk==1.32.1
+opentelemetry-sdk==1.33.0
     # via
     #   billing-collector (pyproject.toml)
     #   eodhp-utils
     #   opentelemetry-processor-baggage
-opentelemetry-semantic-conventions==0.53b1
+opentelemetry-semantic-conventions==0.54b0
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-sdk
-packaging==24.2
+packaging==25.0
     # via opentelemetry-instrumentation
-pulsar-client==3.6.1
+pulsar-client==3.7.0
     # via
     #   billing-collector (pyproject.toml)
     #   eodhp-utils
+pysubnettree==0.37
+    # via eodhp-utils
 python-dateutil==2.9.0.post0
     # via botocore
 python-json-logger==3.3.0
@@ -80,12 +84,14 @@ referencing==0.36.2
     #   jsonschema
     #   jsonschema-specifications
 requests==2.32.3
-    # via billing-collector (pyproject.toml)
-rpds-py==0.24.0
+    # via
+    #   billing-collector (pyproject.toml)
+    #   eodhp-utils
+rpds-py==0.25.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.11.4
+s3transfer==0.12.0
     # via boto3
 six==1.17.0
     # via python-dateutil


### PR DESCRIPTION
The service currently is not starting in the cluster because Click is used but not included in the dependency list. This updates the dependencies and adds Click. It works in development because black and pip-tools both want it.
